### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.2"
 edition = "2021"
 description = "Lexes CSS modules returning their dependencies metadata"
 license = "MIT"
+repository = "https://github.com/ahabhgk/css-module-lexer"
 
 [dependencies]
 smallvec = "1.13"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.