### PR TITLE
fix: correctly consume escape for consume string token

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -348,28 +348,24 @@ impl<'s> Lexer<'s> {
     pub fn consume_string<T: Visitor<'s>>(&mut self, visitor: &mut T, end: char) -> Option<()> {
         let start = self.cur_pos()?;
         self.consume();
-        'outer: loop {
+        loop {
             let c = self.cur()?;
             if c == end {
                 self.consume();
                 break;
-            }
-            if is_new_line(c) {
+            } else if is_new_line(c) {
                 break;
-            }
-            while self.cur()? == C_REVERSE_SOLIDUS {
+            } else if c == C_REVERSE_SOLIDUS {
                 self.consume();
-                if is_new_line(self.cur()?) {
+                let c2 = self.cur()?;
+                if is_new_line(c2) {
                     self.consume();
-                } else {
+                } else if are_valid_escape(c, c2) {
                     self.consume_escaped()?;
-                    if self.cur()? == end {
-                        self.consume();
-                        break 'outer;
-                    }
                 }
+            } else {
+                self.consume();
             }
-            self.consume();
         }
         visitor.string(self, start, self.cur_pos()?)
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -348,7 +348,7 @@ impl<'s> Lexer<'s> {
     pub fn consume_string<T: Visitor<'s>>(&mut self, visitor: &mut T, end: char) -> Option<()> {
         let start = self.cur_pos()?;
         self.consume();
-        loop {
+        'outer: loop {
             let c = self.cur()?;
             if c == end {
                 self.consume();
@@ -357,13 +357,16 @@ impl<'s> Lexer<'s> {
             if is_new_line(c) {
                 break;
             }
-            if c == C_REVERSE_SOLIDUS {
+            while self.cur()? == C_REVERSE_SOLIDUS {
                 self.consume();
-                let c2 = self.cur()?;
-                if is_new_line(c2) {
+                if is_new_line(self.cur()?) {
                     self.consume();
-                } else if are_valid_escape(c, c2) {
+                } else {
                     self.consume_escaped()?;
+                    if self.cur()? == end {
+                        self.consume();
+                        break 'outer;
+                    }
                 }
             }
             self.consume();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -359,6 +359,34 @@ fn url_2() {
 }
 
 #[test]
+fn url_3() {
+    let input = r#"body{content: "\f101";background-image:url(./img.png)}"#;
+    let (dependencies, warnings) = collect_dependencies(input, Mode::Css);
+    assert!(warnings.is_empty());
+    assert_url_dependency(
+        input,
+        &dependencies[0],
+        "./img.png",
+        UrlRangeKind::Function,
+        "url(./img.png)",
+    );
+}
+
+#[test]
+fn url_4() {
+    let input = r#"body{content: "\f\"101";background-image:url(./img.png)}"#;
+    let (dependencies, warnings) = collect_dependencies(input, Mode::Css);
+    assert!(warnings.is_empty());
+    assert_url_dependency(
+        input,
+        &dependencies[0],
+        "./img.png",
+        UrlRangeKind::Function,
+        "url(./img.png)",
+    );
+}
+
+#[test]
 fn duplicate_url() {
     let input = indoc! {r#"
         @import url(./a.css) url(./a.css);


### PR DESCRIPTION
fix https://github.com/web-infra-dev/rspack/issues/8384

I'm not sure if this fix is correct, so feel free to modify it or just close the PR if needed.